### PR TITLE
power:qpnp-charger: extended charge time from 30s to 100s when batter…

### DIFF
--- a/drivers/power/qpnp-charger.c
+++ b/drivers/power/qpnp-charger.c
@@ -3778,7 +3778,7 @@ qpnp_chg_adjust_vddmax(struct qpnp_chg_chip *chip, int vbat_mv)
 	qpnp_chg_set_appropriate_vddmax(chip);
 }
 
-#define CONSECUTIVE_COUNT	3
+#define CONSECUTIVE_COUNT	10
 #define VBATDET_MAX_ERR_MV	50
 static void
 qpnp_eoc_work(struct work_struct *work)


### PR DESCRIPTION
…y status is near to full

When charger is online for a long time, such as 12 hour, the battery status changes from charging to full and resumes charging.
The reason is that battery is not full at the first full state. So increse charge time from 30s to 100s when battery status is
near to full. This methods will reduce the number of recharging times

BUG:24316771
Signed-off-by: l00228880 l00228880@notesmail.huawei.com
Signed-off-by: Pranav Vashi neobuddy89@gmail.com
